### PR TITLE
fixed stack link crash

### DIFF
--- a/src/main/java/gigaherz/guidebook/guidebook/BookDocument.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/BookDocument.java
@@ -84,12 +84,10 @@ public class BookDocument
         Item item=stack.getItem();
         int damage=stack.getItemDamage();
 
-        if(stackLinks.containsRow(item)){
-            if(stackLinks.containsColumn(damage)){
-                return stackLinks.get(item,damage);
-            }else if(stackLinks.contains(item,-1)){
-                return stackLinks.get(item,-1);
-            }
+        if(stackLinks.contains(item,damage)){
+            return stackLinks.get(item,damage);
+        }else if(stackLinks.contains(item,-1)){
+            return stackLinks.get(item,-1);
         }
         return null;
     }


### PR DESCRIPTION
I knew the PR went too smoothly to be true. This caused a crash because it doesn't check if the damage column exists for the item but instead if the damage column exists in general.