### PR TITLE
Adds scale attribute to text paragraphs

### DIFF
--- a/src/main/java/gigaherz/guidebook/guidebook/BookDocument.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/BookDocument.java
@@ -318,7 +318,8 @@ public class BookDocument
                 p.alignment = 1;
                 p.space = 4;
                 p.underline = true;
-                p.italics = true;
+                p.italics = false;
+                p.scale = 1.5f;
 
                 elements.add(p);
 

--- a/src/main/java/gigaherz/guidebook/guidebook/IBookGraphics.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/IBookGraphics.java
@@ -32,7 +32,7 @@ public interface IBookGraphics
 
     void navigateBack();
 
-    int addStringWrapping(int left, int top, String s, int color, int align);
+    int addStringWrapping(int left, int top, String s, int color, int align, float scale);
 
     boolean mouseClicked(int mouseButton);
 

--- a/src/main/java/gigaherz/guidebook/guidebook/client/BookRendering.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/client/BookRendering.java
@@ -250,38 +250,38 @@ public class BookRendering implements IBookGraphics
         history.push(new PageRef(currentChapter, currentPair * 2));
     }
 
-    private int getSplitWidth(FontRenderer fontRenderer, String s, float scalingFactor)
+    private int getSplitWidth(FontRenderer fontRenderer, String s, float scale)
     {
-        int height = (int)(fontRenderer.getWordWrappedHeight(s, (int)(pageWidth / scalingFactor)) * scalingFactor);
-        return height > (fontRenderer.FONT_HEIGHT * scalingFactor) ? pageWidth : (int)(fontRenderer.getStringWidth(s) * scalingFactor);
+        int height = (int)(fontRenderer.getWordWrappedHeight(s, (int)(pageWidth / scale)) * scale);
+        return height > (fontRenderer.FONT_HEIGHT * scale) ? pageWidth : (int)(fontRenderer.getStringWidth(s) * scale);
     }
 
     @Override
-    public int addStringWrapping(int left, int top, String s, int color, int align, float scalingFactor)
+    public int addStringWrapping(int left, int top, String s, int color, int align, float scale)
     {
         FontRenderer fontRenderer = gui.getFontRenderer();
 
         if (align == 1)
         {
-            left += (pageWidth - getSplitWidth(fontRenderer, s, scalingFactor)) / 2;
+            left += (pageWidth - getSplitWidth(fontRenderer, s, scale)) / 2;
         }
         else if (align == 2)
         {
-            left += pageWidth - getSplitWidth(fontRenderer, s, scalingFactor);
+            left += pageWidth - getSplitWidth(fontRenderer, s, scale);
         }
 
         // Does scaling need to be performed?
-        if(scalingFactor != 1f) {
+        if(scale != 1f) {
             GlStateManager.pushMatrix(); {
-                GlStateManager.scale(scalingFactor, scalingFactor, 1f);
-                fontRenderer.drawSplitString(s, (int)(left / scalingFactor), (int)(top / scalingFactor), (int)(pageWidth / scalingFactor), color);
+                GlStateManager.scale(scale, scale, 1f);
+                fontRenderer.drawSplitString(s, (int)(left / scale), (int)(top / scale), (int)(pageWidth / scale), color);
             }
             GlStateManager.popMatrix();
         } else {
             fontRenderer.drawSplitString(s, left, top, pageWidth, color);
         }
 
-        return (int)(fontRenderer.getWordWrappedHeight(s, (int)(pageWidth / scalingFactor)) * scalingFactor);
+        return (int)(fontRenderer.getWordWrappedHeight(s, (int)(pageWidth / scale)) * scale);
     }
 
     @Override

--- a/src/main/java/gigaherz/guidebook/guidebook/client/BookRendering.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/client/BookRendering.java
@@ -271,7 +271,7 @@ public class BookRendering implements IBookGraphics
         }
 
         // Does scaling need to be performed?
-        if(scale != 1f) {
+        if(!(MathHelper.epsilonEquals(scale, 1.0f))) {
             GlStateManager.pushMatrix(); {
                 GlStateManager.scale(scale, scale, 1f);
                 fontRenderer.drawSplitString(s, (int)(left / scale), (int)(top / scale), (int)(pageWidth / scale), color);

--- a/src/main/java/gigaherz/guidebook/guidebook/client/BookRendering.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/client/BookRendering.java
@@ -257,21 +257,31 @@ public class BookRendering implements IBookGraphics
     }
 
     @Override
-    public int addStringWrapping(int left, int top, String s, int color, int align)
+    public int addStringWrapping(int left, int top, String s, int color, int align, float scalingFactor)
     {
         FontRenderer fontRenderer = gui.getFontRenderer();
 
         if (align == 1)
         {
-            left += (pageWidth - getSplitWidth(fontRenderer, s)) / 2;
+            left += (pageWidth - (getSplitWidth(fontRenderer, s) * scalingFactor)) / 2;
         }
         else if (align == 2)
         {
-            left += pageWidth - getSplitWidth(fontRenderer, s);
+            left += pageWidth - getSplitWidth(fontRenderer, s) * scalingFactor;
         }
 
-        fontRenderer.drawSplitString(s, left, top, pageWidth, color);
-        return fontRenderer.getWordWrappedHeight(s, pageWidth);
+        // Does scaling need to be performed?
+        if(scalingFactor != 1f) {
+            GlStateManager.pushMatrix(); {
+                GlStateManager.scale(scalingFactor, scalingFactor, 1f);
+                fontRenderer.drawSplitString(s, (int)(left / scalingFactor), (int)(top / scalingFactor), (int)(pageWidth / scalingFactor), color);
+            }
+            GlStateManager.popMatrix();
+        } else {
+            fontRenderer.drawSplitString(s, left, top, pageWidth, color);
+        }
+
+        return (int)(fontRenderer.getWordWrappedHeight(s, pageWidth) * scalingFactor);
     }
 
     @Override
@@ -405,7 +415,7 @@ public class BookRendering implements IBookGraphics
         drawPage(right, top, currentPair * 2 + 1);
 
         String cnt = "" + ((book.getChapter(currentChapter).startPair + currentPair) * 2 + 1) + "/" + (book.getTotalPairCount() * 2);
-        addStringWrapping(left, bottom, cnt, 0xFF000000, 1);
+        addStringWrapping(left, bottom, cnt, 0xFF000000, 1, 1f);
 
         if (hasScale)
         {

--- a/src/main/java/gigaherz/guidebook/guidebook/client/BookRendering.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/client/BookRendering.java
@@ -263,7 +263,7 @@ public class BookRendering implements IBookGraphics
 
         if (align == 1)
         {
-            left += (pageWidth - (getSplitWidth(fontRenderer, s, scalingFactor))) / 2;
+            left += (pageWidth - getSplitWidth(fontRenderer, s, scalingFactor)) / 2;
         }
         else if (align == 2)
         {

--- a/src/main/java/gigaherz/guidebook/guidebook/client/BookRendering.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/client/BookRendering.java
@@ -250,10 +250,10 @@ public class BookRendering implements IBookGraphics
         history.push(new PageRef(currentChapter, currentPair * 2));
     }
 
-    private int getSplitWidth(FontRenderer fontRenderer, String s)
+    private int getSplitWidth(FontRenderer fontRenderer, String s, float scalingFactor)
     {
-        int height = fontRenderer.getWordWrappedHeight(s, pageWidth);
-        return height > fontRenderer.FONT_HEIGHT ? pageWidth : fontRenderer.getStringWidth(s);
+        int height = (int)(fontRenderer.getWordWrappedHeight(s, (int)(pageWidth / scalingFactor)) * scalingFactor);
+        return height > (fontRenderer.FONT_HEIGHT * scalingFactor) ? pageWidth : (int)(fontRenderer.getStringWidth(s) * scalingFactor);
     }
 
     @Override
@@ -263,11 +263,11 @@ public class BookRendering implements IBookGraphics
 
         if (align == 1)
         {
-            left += (pageWidth - (getSplitWidth(fontRenderer, s) * scalingFactor)) / 2;
+            left += (pageWidth - (getSplitWidth(fontRenderer, s, scalingFactor))) / 2;
         }
         else if (align == 2)
         {
-            left += pageWidth - getSplitWidth(fontRenderer, s) * scalingFactor;
+            left += pageWidth - getSplitWidth(fontRenderer, s, scalingFactor);
         }
 
         // Does scaling need to be performed?
@@ -281,7 +281,7 @@ public class BookRendering implements IBookGraphics
             fontRenderer.drawSplitString(s, left, top, pageWidth, color);
         }
 
-        return (int)(fontRenderer.getWordWrappedHeight(s, pageWidth) * scalingFactor);
+        return (int)(fontRenderer.getWordWrappedHeight(s, (int)(pageWidth / scalingFactor)) * scalingFactor);
     }
 
     @Override

--- a/src/main/java/gigaherz/guidebook/guidebook/client/BookRendering.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/client/BookRendering.java
@@ -271,13 +271,17 @@ public class BookRendering implements IBookGraphics
         }
 
         // Does scaling need to be performed?
-        if(!(MathHelper.epsilonEquals(scale, 1.0f))) {
-            GlStateManager.pushMatrix(); {
+        if(!(MathHelper.epsilonEquals(scale, 1.0f)))
+        {
+            GlStateManager.pushMatrix();
+            {
                 GlStateManager.scale(scale, scale, 1f);
                 fontRenderer.drawSplitString(s, (int)(left / scale), (int)(top / scale), (int)(pageWidth / scale), color);
             }
             GlStateManager.popMatrix();
-        } else {
+        }
+        else
+        {
             fontRenderer.drawSplitString(s, left, top, pageWidth, color);
         }
 

--- a/src/main/java/gigaherz/guidebook/guidebook/elements/Link.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/elements/Link.java
@@ -96,7 +96,7 @@ public class Link extends Paragraph implements IClickablePageElement
     {
         bounds = nav.getStringBounds(text, left, top);
 
-        return nav.addStringWrapping(left + indent, top, text, isHovering ? colorHover : color, alignment) + space;
+        return nav.addStringWrapping(left + indent, top, text, isHovering ? colorHover : color, alignment, scale) + space;
     }
 
     @Override

--- a/src/main/java/gigaherz/guidebook/guidebook/elements/Paragraph.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/elements/Paragraph.java
@@ -1,5 +1,6 @@
 package gigaherz.guidebook.guidebook.elements;
 
+import com.google.common.primitives.Floats;
 import com.google.common.primitives.Ints;
 import gigaherz.guidebook.guidebook.IBookGraphics;
 import net.minecraft.util.text.TextFormatting;
@@ -16,6 +17,7 @@ public class Paragraph implements IPageElement
     public int color = 0xFF000000;
     public int indent = 0;
     public int space = 2;
+    public float scale = 1f;
     public boolean bold;
     public boolean italics;
     public boolean underline;
@@ -32,7 +34,7 @@ public class Paragraph implements IPageElement
         if (bold) textWithFormat = TextFormatting.BOLD + textWithFormat;
         if (italics) textWithFormat = TextFormatting.ITALIC + textWithFormat;
         if (underline) textWithFormat = TextFormatting.UNDERLINE + textWithFormat;
-        return nav.addStringWrapping(left + indent, top, textWithFormat, color, alignment) + space;
+        return nav.addStringWrapping(left + indent, top, textWithFormat, color, alignment, scale) + space;
     }
 
     @Override
@@ -66,6 +68,11 @@ public class Paragraph implements IPageElement
         if (attr != null)
         {
             space = Ints.tryParse(attr.getTextContent());
+        }
+
+        attr = attributes.getNamedItem("scale");
+        if(attr != null) {
+            scale = Floats.tryParse(attr.getTextContent());
         }
 
         attr = attributes.getNamedItem("bold");

--- a/src/main/java/gigaherz/guidebook/guidebook/elements/Paragraph.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/elements/Paragraph.java
@@ -136,6 +136,7 @@ public class Paragraph implements IPageElement
         paragraph.bold = bold;
         paragraph.italics = italics;
         paragraph.underline = underline;
+        paragraph.scale = scale;
         return paragraph;
     }
 }

--- a/src/main/resources/assets/gbook/xml/guidebook.xml
+++ b/src/main/resources/assets/gbook/xml/guidebook.xml
@@ -125,7 +125,7 @@
       <p indent="16">&lt;/page&gt;</p>
       <p indent="8">&lt;/chapter&gt;</p>
     </page>
-    <page>
+    <page id="text">
       <title>Paragraphs and titles</title>
       <p space="8">Inside pages there can be text, alongside other page elements. The primary way of adding text is through paragraph elements 'p'.</p>
       <p indent="12" space="8">&lt;p&gt;Text&lt;/p&gt;</p>
@@ -150,7 +150,7 @@
       <p scale="1.5" align="center">larger</p>
       <p scale="2.0" align="center">huge</p>
     </page>
-    <page id="text_3">
+    <page>
       <p space="8">Finally, to avoid writing so many formatting codes. Section titles can be shortened with the 'title' tag, which has different default formattings.</p>
       <p indent="8" space="8">&lt;title&gt;Title Here&lt;/title&gt;</p>
       <title>Title Here</title>

--- a/src/main/resources/assets/gbook/xml/guidebook.xml
+++ b/src/main/resources/assets/gbook/xml/guidebook.xml
@@ -20,11 +20,11 @@
       The % refers to a % of the page's height, while integer values refer to pixels.
       -->
       <space height="33%" />
-      <p space="0" align="center">Welcome</p>
-      <p space="0" align="center">to</p>
-      <p space="0" align="center">Guidebook</p>
-      <p space="6" align="center">__________</p>
-      <p align="center">by Gigaherz</p>
+      <p space="0" align="center" scale="2">Welcome</p>
+      <p space="0" align="center" scale="2">to</p>
+      <p space="0" align="center" scale="2">Guidebook</p>
+      <p space="6" align="center" scale="2">__________</p>
+      <p align="center" scale="1.5">by Gigaherz</p>
     </page>
     <page>
       <title>Index</title>

--- a/src/main/resources/assets/gbook/xml/guidebook.xml
+++ b/src/main/resources/assets/gbook/xml/guidebook.xml
@@ -125,7 +125,7 @@
       <p indent="16">&lt;/page&gt;</p>
       <p indent="8">&lt;/chapter&gt;</p>
     </page>
-    <page id="text">
+    <page>
       <title>Paragraphs and titles</title>
       <p space="8">Inside pages there can be text, alongside other page elements. The primary way of adding text is through paragraph elements 'p'.</p>
       <p indent="12" space="8">&lt;p&gt;Text&lt;/p&gt;</p>
@@ -142,6 +142,15 @@
       <p indent="8" space="8">&lt;p indent=&quot;20&quot; space=&quot;20&quot;&gt;Indented spaced text&lt;/p&gt;</p>
       <p indent="20" space="20">Indented spaced text</p>
       <p space="12">Text after</p>
+      <p space="8">To make text larger or smaller, you can specify the 'scale' attribute, which takes a decimal number</p>
+      <p indent="8">&lt;p scale="1.0"&gt;normal&lt;/p&gt;</p>
+      <p indent="8">&lt;p scale="1.5"&gt;larger&lt;/p&gt;</p>
+      <p indent="8" space="8">&lt;p scale="2.0"&gt;huge&lt;/p&gt;</p>
+      <p scale="1.0" align="center">normal</p>
+      <p scale="1.5" align="center">larger</p>
+      <p scale="2.0" align="center">huge</p>
+    </page>
+    <page id="text_3">
       <p space="8">Finally, to avoid writing so many formatting codes. Section titles can be shortened with the 'title' tag, which has different default formattings.</p>
       <p indent="8" space="8">&lt;title&gt;Title Here&lt;/title&gt;</p>
       <title>Title Here</title>


### PR DESCRIPTION
- Adds the `scale` attribute to the `<p>` tag which accepts a decimal (specifically a `float`)
    - Example: `<p scale="2">This text is twice as large</p>`
    - At its core, it uses `GlStateManager.scale(scale, scale, 1f);` to scale the text rendering
- Modifies the properties of the `<title>` tag to add have `scale="1.5"` and remove `italics="true"`
- Adds a `float scale` parameter to each of the text-rendering methods that allow scaled text
- Updates the in-game documentation to feature this new attribute
