### PR TITLE
[WIP] Multiblock Display System

### DIFF
--- a/src/main/java/gigaherz/guidebook/guidebook/BookDocument.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/BookDocument.java
@@ -384,6 +384,21 @@ public class BookDocument
                     i.parse(elementItem.getAttributes());
                 }
             }
+            else if (nodeName.equals("multiblock"))
+            {
+                MultiblockPanel mp = new MultiblockPanel();
+                elements.add(mp);
+
+                if(elementItem.hasAttributes())
+                {
+                    mp.parse(elementItem.getAttributes());
+                }
+
+                if(elementItem.hasChildNodes())
+                {
+                    mp.parseChildren(elementItem.getChildNodes());
+                }
+             }
             else if (templates.containsKey(nodeName))
             {
                 TemplateDefinition tDef = templates.get(nodeName);

--- a/src/main/java/gigaherz/guidebook/guidebook/ParseUtils.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/ParseUtils.java
@@ -1,0 +1,65 @@
+package gigaherz.guidebook.guidebook;
+
+import com.sun.javafx.geom.Vec3f;
+import gigaherz.guidebook.GuidebookMod;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.awt.*;
+
+/**
+ * @author joazlazer
+ *
+ * Provides a variety of parsing utilities to consolidate common code
+ */
+public class ParseUtils {
+    /**
+     * Parses a vector from the input String that is either in the format of 'Xf' or 'Xf,Yf,Zf'
+     * @param toParse The input String
+     * @return A Vec3f containing the parsed information if valid, and <code>null</code> if parsing failed
+     */
+    @Nullable
+    public static Vec3f parseVec3f(@Nonnull String toParse) {
+        try {
+            if(toParse.indexOf(',') != -1) {
+                // Parse as comment-separated x,y,z vector
+                float x = Float.parseFloat(toParse.substring(0, toParse.indexOf(',')));
+                float y = Float.parseFloat(toParse.substring(toParse.indexOf(',') + 1, toParse.lastIndexOf(',')));
+                float z = Float.parseFloat(toParse.substring(toParse.lastIndexOf(',')));
+                return new Vec3f(x, y, z);
+
+            } else {
+                // Parse as single-digit cubic vector
+                float s = Float.parseFloat(toParse);
+                return new Vec3f(s, s, s);
+            }
+        } catch (NumberFormatException ex) {
+            GuidebookMod.logger.warn(String.format("Input Vector3f string '%s' cannot be parsed: %s", toParse, ex.getMessage()));
+            return null;
+        }
+    }
+
+    /**
+     * Parses a vector from the input String that is either in the format of 'Xi' or 'Xi,Yi'
+     * @param toParse The input String
+     * @return A Point containing the parsed information if valid, and <code>null</code> if parsing failed
+     */
+    @Nullable
+    public static Point parsePoint(@Nonnull String toParse) {
+        try {
+            if(toParse.indexOf(',') != -1) {
+                // Parse as comment-separated x,y vector
+                int x = Integer.parseInt(toParse.substring(0, toParse.indexOf(',')));
+                int y = Integer.parseInt(toParse.substring(toParse.lastIndexOf(',')));
+                return new Point(x, y);
+            } else {
+                // Parse as single-digit square vector
+                int s = Integer.parseInt(toParse);
+                return new Point(s, s);
+            }
+        } catch (NumberFormatException ex) {
+            GuidebookMod.logger.warn(String.format("Input Point(x,y) string '%s' cannot be parsed: %s", toParse, ex.getMessage()));
+            return null;
+        }
+    }
+}

--- a/src/main/java/gigaherz/guidebook/guidebook/elements/MultiblockPanel.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/elements/MultiblockPanel.java
@@ -5,10 +5,12 @@ import com.google.common.primitives.Ints;
 import com.sun.javafx.geom.Vec3f;
 import gigaherz.guidebook.guidebook.IBookGraphics;
 import gigaherz.guidebook.guidebook.ParseUtils;
-import gigaherz.guidebook.guidebook.multiblock.IMultiblockComponent;
+import gigaherz.guidebook.guidebook.multiblock.MultiblockComponent;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
+import java.util.ArrayList;
 
 public class MultiblockPanel implements IPageElement {
     private int height = 256; // Default height
@@ -18,7 +20,8 @@ public class MultiblockPanel implements IPageElement {
     private float spin = 0f;
     private OffsetOrigin offsetOrigin = OffsetOrigin.CENTER;
     private Vec3f offset = new Vec3f(0f, 0f, 0f);
-    private IMultiblockComponent[] components;
+    private int layerGap = 0;
+    private MultiblockComponent[] components;
 
     @Override
     public int apply(IBookGraphics nav, int left, int top) {
@@ -35,6 +38,11 @@ public class MultiblockPanel implements IPageElement {
         attr = attributes.getNamedItem("indent");
         if (attr != null) {
             indent = Ints.tryParse(attr.getTextContent());
+        }
+
+        attr = attributes.getNamedItem("layerGap");
+        if (attr != null) {
+            layerGap = Ints.tryParse(attr.getTextContent());
         }
 
         attr = attributes.getNamedItem("poles");
@@ -64,7 +72,15 @@ public class MultiblockPanel implements IPageElement {
     }
 
     public void parseChildren(NodeList childNodes) {
-
+        ArrayList<MultiblockComponent> componentList = new ArrayList<>();
+        for(int i = 0; i < childNodes.getLength(); ++i) {
+            Node componentNode = childNodes.item(i);
+            MultiblockComponent.MultiblockComponentFactory componentFactory = MultiblockComponent.getFactory(componentNode.getNodeName());
+            if(componentFactory != null) {
+                componentList.add(componentFactory.parse(componentNode));
+            }
+        }
+        components = componentList.toArray(new MultiblockComponent[componentList.size()]);
     }
 
     @Override

--- a/src/main/java/gigaherz/guidebook/guidebook/elements/MultiblockPanel.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/elements/MultiblockPanel.java
@@ -1,0 +1,104 @@
+package gigaherz.guidebook.guidebook.elements;
+
+import com.google.common.primitives.Floats;
+import com.google.common.primitives.Ints;
+import com.sun.javafx.geom.Vec3f;
+import gigaherz.guidebook.guidebook.IBookGraphics;
+import gigaherz.guidebook.guidebook.ParseUtils;
+import gigaherz.guidebook.guidebook.multiblock.IMultiblockComponent;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class MultiblockPanel implements IPageElement {
+    private int height = 256; // Default height
+    private int indent = 0;
+    private PoleMode poles = PoleMode.OFF;
+    private FloorMode floor = FloorMode.GRID;
+    private float spin = 0f;
+    private OffsetOrigin offsetOrigin = OffsetOrigin.CENTER;
+    private Vec3f offset = new Vec3f(0f, 0f, 0f);
+    private IMultiblockComponent[] components;
+
+    @Override
+    public int apply(IBookGraphics nav, int left, int top) {
+        return 0;
+    }
+
+    @Override
+    public void parse(NamedNodeMap attributes) {
+        Node attr = attributes.getNamedItem("height");
+        if (attr != null) {
+            height = Ints.tryParse(attr.getTextContent());
+        }
+
+        attr = attributes.getNamedItem("indent");
+        if (attr != null) {
+            indent = Ints.tryParse(attr.getTextContent());
+        }
+
+        attr = attributes.getNamedItem("poles");
+        if (attr != null) {
+            poles = PoleMode.parse(attr.getTextContent());
+        }
+
+        attr = attributes.getNamedItem("floor");
+        if (attr != null) {
+            floor = FloorMode.parse(attr.getTextContent());
+        }
+
+        attr = attributes.getNamedItem("spin");
+        if (attr != null) {
+            spin = Floats.tryParse(attr.getTextContent());
+        }
+
+        attr = attributes.getNamedItem("offset");
+        if (attr != null) {
+            offset = ParseUtils.parseVec3f(attr.getTextContent());
+        }
+
+        attr = attributes.getNamedItem("offsetOrigin");
+        if (attr != null) {
+            offsetOrigin = OffsetOrigin.parse(attr.getTextContent());
+        }
+    }
+
+    public void parseChildren(NodeList childNodes) {
+
+    }
+
+    @Override
+    public IPageElement copy() {
+        return null;
+    }
+
+    private enum PoleMode {
+        OFF, ON, BELOW_ITEMS;
+        private static PoleMode parse(String string) {
+            if(string.equalsIgnoreCase("grid")) return ON;
+            else if(string.equalsIgnoreCase("below_items")) return BELOW_ITEMS;
+            else return OFF; // default
+        }
+    }
+
+    private enum FloorMode {
+        OFF, UNDER, ADJACENT, GRID;
+        private static FloorMode parse(String string) {
+            if(string.equalsIgnoreCase("grid")) return GRID;
+            else if(string.equalsIgnoreCase("under")) return UNDER;
+            else if(string.equalsIgnoreCase("adjacent")) return ADJACENT;
+            else return OFF; // default
+        }
+    }
+
+    private enum OffsetOrigin {
+        CENTER, LEFT, RIGHT, FRONT, BACK;
+        private static OffsetOrigin parse(String string) {
+            if(string.equalsIgnoreCase("left")) return LEFT;
+            else if(string.equalsIgnoreCase("right")) return RIGHT;
+            else if(string.equalsIgnoreCase("front")) return FRONT;
+            else if(string.equalsIgnoreCase("back")) return BACK;
+            else return CENTER; // default
+        }
+    }
+}

--- a/src/main/java/gigaherz/guidebook/guidebook/multiblock/ComponentBlock.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/multiblock/ComponentBlock.java
@@ -1,5 +1,16 @@
 package gigaherz.guidebook.guidebook.multiblock;
 
-public class ComponentBlock extends MultiblockComponent {
+import org.w3c.dom.Node;
 
+public class ComponentBlock extends MultiblockComponent {
+    public static class Factory extends MultiblockComponent.MultiblockComponentFactory {
+        public Factory() {
+            this.setRegistryName("block");
+        }
+
+        @Override
+        public MultiblockComponent parse(Node thisNode) {
+            return new ComponentBlock();
+        }
+    }
 }

--- a/src/main/java/gigaherz/guidebook/guidebook/multiblock/ComponentBlock.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/multiblock/ComponentBlock.java
@@ -1,0 +1,5 @@
+package gigaherz.guidebook.guidebook.multiblock;
+
+public class ComponentBlock extends MultiblockComponent {
+
+}

--- a/src/main/java/gigaherz/guidebook/guidebook/multiblock/ComponentItem.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/multiblock/ComponentItem.java
@@ -1,0 +1,5 @@
+package gigaherz.guidebook.guidebook.multiblock;
+
+public class ComponentItem extends MultiblockComponent {
+
+}

--- a/src/main/java/gigaherz/guidebook/guidebook/multiblock/ComponentItem.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/multiblock/ComponentItem.java
@@ -1,5 +1,16 @@
 package gigaherz.guidebook.guidebook.multiblock;
 
-public class ComponentItem extends MultiblockComponent {
+import org.w3c.dom.Node;
 
+public class ComponentItem extends MultiblockComponent {
+    public static class Factory extends MultiblockComponent.MultiblockComponentFactory {
+        public Factory() {
+            this.setRegistryName("stack");
+        }
+
+        @Override
+        public MultiblockComponent parse(Node thisNode) {
+            return new ComponentItem();
+        }
+    }
 }

--- a/src/main/java/gigaherz/guidebook/guidebook/multiblock/MultiblockComponent.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/multiblock/MultiblockComponent.java
@@ -1,0 +1,5 @@
+package gigaherz.guidebook.guidebook.multiblock;
+
+public abstract class MultiblockComponent {
+
+}

--- a/src/main/java/gigaherz/guidebook/guidebook/multiblock/MultiblockComponent.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/multiblock/MultiblockComponent.java
@@ -1,5 +1,73 @@
 package gigaherz.guidebook.guidebook.multiblock;
 
-public abstract class MultiblockComponent {
+import gigaherz.guidebook.GuidebookMod;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.IForgeRegistryEntry;
+import net.minecraftforge.registries.RegistryBuilder;
+import org.w3c.dom.Node;
 
+import javax.annotation.Nullable;
+
+/**
+ * @author joazlazer
+ *
+ * A class designed to be implemented by any custom usages of multiblock display componenets
+ * The default implementations currently are:
+ *  - ComponentItem, which handles display of ItemStacks via Stacks
+ *  - ComponentBlock, which handles display of Blocks
+ */
+public abstract class MultiblockComponent {
+    public static IForgeRegistry<MultiblockComponentFactory> factoryRegistry;
+
+    /**
+     * Handles registry of the MultiblockComponentFactory registry to the meta-registry and register the default MultiblockComponentFactory's
+     */
+    @Mod.EventBusSubscriber(modid = GuidebookMod.MODID)
+    public static class RegistrationHandler {
+        @SubscribeEvent
+        public static void registerRegistries(RegistryEvent.NewRegistry event) {
+            RegistryBuilder rb = new RegistryBuilder<MultiblockComponentFactory>();
+            rb.setType(MultiblockComponentFactory.class);
+            rb.setName(new ResourceLocation(GuidebookMod.MODID, "multiblock_component_factory"));
+            factoryRegistry = rb.create();
+        }
+
+        @SubscribeEvent
+        public static void registerDefaults(RegistryEvent.Register<MultiblockComponentFactory> event) {
+            event.getRegistry().register(new ComponentBlock.Factory());
+            event.getRegistry().register(new ComponentItem.Factory());
+        }
+    }
+
+    /**
+     * Gets the multiblock component factory with the specified factory name
+     * NOTE: Ignores registry name domains
+     * @param name
+     * @return Null if not found; otherwise, the factory
+     */
+    @Nullable
+    public static MultiblockComponentFactory getFactory(String name) {
+        for(MultiblockComponentFactory factory : factoryRegistry.getValues()) {
+            if(factory.getRegistryName().getResourcePath().equals(name)) return factory;
+        }
+        return null; // If not found, return null
+    }
+
+    /**
+     * A class that can be registered to the factory registry and is responsible for creating new MultiblockComponents
+     * WARNING: The registry name's domain is ignored when determining the correct factory to use when parsing from XML
+     */
+    public static abstract class MultiblockComponentFactory extends IForgeRegistryEntry.Impl<MultiblockComponentFactory> {
+        /**
+         * Parses the current node and is responsible for creating a new instance of the MultiblockComponent with its new parsed values
+         * @param thisNode The current inner node of the MultiblockPanel
+         * @return A new instance of the MultiblockComponent implementation with its values set
+         */
+        public abstract MultiblockComponent parse(Node thisNode);
+    }
 }
+


### PR DESCRIPTION
## Changes
- Adds the new `<multiblock>` tag which allows guidebook authors to display a multiblock structure
- Adds the classes necessary to implement custom multiblock components or special renderers by extending the abstract class `multiblock.MultiblockComponenet`. It has default implementations:
  - `multiblock.ComponentItem` which supports rendering of an `ItemStack` via a `Stack`
  - `multiblock.ComponentBlock` which supports rendering of a `Block` and should accept a `BlockState`

## Documentation
Designed to mimic the functionality (and some) of:

![TC's Thaumonomicon](https://vignette3.wikia.nocookie.net/thaumcraft-3/images/1/1a/Infernal_Furnace_Crafting.png/revision/latest?cb=20121228050818)