### PR TITLE
Fixing #24: Guidebooks appear in every Creative Tab

### DIFF
--- a/src/main/java/gigaherz/guidebook/guidebook/ItemGuidebook.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/ItemGuidebook.java
@@ -67,9 +67,12 @@ public class ItemGuidebook extends ItemRegistered
     @Override
     public void getSubItems(CreativeTabs tab, NonNullList<ItemStack> subItems)
     {
-        for (ResourceLocation resourceLocation : GuidebookMod.proxy.getBooksList())
+        if (this.isInCreativeTab(tab))
         {
-            subItems.add(of(resourceLocation));
+            for (ResourceLocation resourceLocation : GuidebookMod.proxy.getBooksList())
+            {
+                subItems.add(of(resourceLocation));
+            }
         }
     }
 


### PR DESCRIPTION
This should fix #24. The bug occurs because the Item#getSubItems function is now called for every creative tab allowing items to be in multiple tabs at once. Now the item has to check if it's the right one by itself.