### PR TITLE
Add a command to reload guide books

### DIFF
--- a/src/main/java/gigaherz/guidebook/client/ClientProxy.java
+++ b/src/main/java/gigaherz/guidebook/client/ClientProxy.java
@@ -13,6 +13,7 @@ import gigaherz.guidebook.guidebook.conditions.CompositeCondition;
 import gigaherz.guidebook.guidebook.conditions.GameStageCondition;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.ClientCommandHandler;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ModelLoaderRegistry;
 import net.minecraftforge.client.model.obj.OBJLoader;
@@ -56,6 +57,8 @@ public class ClientProxy implements IModProxy
             GameStageCondition.register();
 
         MinecraftForge.EVENT_BUS.post(new BookRegistryEvent());
+
+        ClientCommandHandler.instance.registerCommand(new GuideCommand());
     }
 
     @Override

--- a/src/main/java/gigaherz/guidebook/client/GuideCommand.java
+++ b/src/main/java/gigaherz/guidebook/client/GuideCommand.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class GuideCommand
     extends CommandBase
@@ -34,9 +35,9 @@ public class GuideCommand
     @Override
     public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos targetPos)
     {
-        if(args.length == 2)
+        if(args.length == 1)
         {
-
+            return subCommands.stream().filter(c -> c.startsWith(args[0])).collect(Collectors.toList());
         }
         return Collections.emptyList();
     }

--- a/src/main/java/gigaherz/guidebook/client/GuideCommand.java
+++ b/src/main/java/gigaherz/guidebook/client/GuideCommand.java
@@ -1,0 +1,86 @@
+package gigaherz.guidebook.client;
+
+import gigaherz.guidebook.guidebook.client.BookRegistry;
+import net.minecraft.client.Minecraft;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraftforge.client.IClientCommand;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class GuideCommand
+    extends CommandBase
+    implements IClientCommand
+{
+    private final List<String> subCommands = Arrays.asList(
+        "reload"
+    );
+
+    @Override
+    public boolean allowUsageWithoutPrefix(ICommandSender sender, String message)
+    {
+        return false;
+    }
+
+    @Override
+    public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos targetPos)
+    {
+        if(args.length == 2)
+        {
+
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getName()
+    {
+        return "guide";
+    }
+
+    @Override
+    public String getUsage(ICommandSender sender)
+    {
+        return "guide [" + String.join(" | ", subCommands) + "]";
+    }
+
+    @Override
+    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException
+    {
+        if(args.length < 1 || !subCommands.contains(args[0]))
+        {
+            sender.sendMessage(new TextComponentString(getUsage(sender)));
+            return;
+        }
+
+        String[] skipFirst = Arrays.stream(args).skip(1).toArray(String[]::new);
+
+        switch(args[0])
+        {
+            case "reload":
+                executeReload(server, sender, skipFirst);
+                break;
+        }
+    }
+
+    @Override
+    public int getRequiredPermissionLevel()
+    {
+        return 0;
+    }
+
+    private void executeReload(MinecraftServer server, ICommandSender sender, String[] args)
+    {
+        BookRegistry.parseAllBooks(Minecraft.getMinecraft().getResourceManager());
+        sender.sendMessage(new TextComponentTranslation("cmd.gbook.guide.done"));
+    }
+}

--- a/src/main/java/gigaherz/guidebook/client/GuideCommand.java
+++ b/src/main/java/gigaherz/guidebook/client/GuideCommand.java
@@ -44,13 +44,13 @@ public class GuideCommand
     @Override
     public String getName()
     {
-        return "guide";
+        return "gbook";
     }
 
     @Override
     public String getUsage(ICommandSender sender)
     {
-        return "guide [" + String.join(" | ", subCommands) + "]";
+        return getName() + " [" + String.join(" | ", subCommands) + "]";
     }
 
     @Override

--- a/src/main/resources/assets/gbook/lang/en_us.lang
+++ b/src/main/resources/assets/gbook/lang/en_us.lang
@@ -6,4 +6,4 @@ text.copyToClipboard.line1=The book wants to put text in your clipboard.
 text.copyToClipboard.line2=Are you sure you want to allow this?
 text.copyToClipboard.success=Text successfully copied.
 
-cmd.gbook.guide.done=Complete
+cmd.gbook.guide.done=Reloading complete

--- a/src/main/resources/assets/gbook/lang/en_us.lang
+++ b/src/main/resources/assets/gbook/lang/en_us.lang
@@ -5,3 +5,5 @@ itemGroup.gbook=Guidebook
 text.copyToClipboard.line1=The book wants to put text in your clipboard.
 text.copyToClipboard.line2=Are you sure you want to allow this?
 text.copyToClipboard.success=Text successfully copied.
+
+cmd.gbook.guide.done=Complete


### PR DESCRIPTION
`/guide reload`

(the `guide` command name can be changed if desired)

Basically, as a mod author trying to write the documentation, having to restart the client every time I fix a typo is a pain in the butt. Even reloading resource packs can take 20 seconds-a few minutes, which is still too long for a rapid iteration cycle.