### PR TITLE
If a template usage only has text, pretend the text is wrapped in a span

### DIFF
--- a/src/main/java/gigaherz/guidebook/guidebook/BookDocument.java
+++ b/src/main/java/gigaherz/guidebook/guidebook/BookDocument.java
@@ -565,6 +565,14 @@ public class BookDocument implements IConditionSource
 
                 parseChildElements(book, elementItem, elementList, templates, false);
 
+                if(elementList.isEmpty())
+                {
+                    if(!elementItem.getTextContent().trim().isEmpty())
+                    {
+                        elementList.add(new ElementSpan(elementItem.getTextContent(), true, true));
+                    }
+                }
+
                 List<Element> effectiveList = tDef.applyTemplate(book, elementList);
 
                 t.innerElements.addAll(effectiveList);


### PR DESCRIPTION
Consider this template:

```
<template id="t">
    <p align="center" space="8">
        <element index="0" underline="true" />
    </p>
</template>
```

Clearly, I want to apply a bunch of formatting to something, probably a header or title.

Currently, you use this like so:

`<t><span>Hello world!</span></t>`

Ew, why do I have to put that extra span in?

With this patch, we can now do this instead:

`<t>Hello World!</t>`

Much nicer!