### PR TITLE
Do not include unrelated misc textures in blocks atlas

### DIFF
--- a/src/main/resources/assets/minecraft/atlases/blocks.json
+++ b/src/main/resources/assets/minecraft/atlases/blocks.json
@@ -7,9 +7,12 @@
       "prefix": "covers/"
     },
     {
-      "type": "directory",
-      "source": "misc",
-      "prefix": "misc/"
+      "type": "single",
+      "resource": "gbook:misc/cover"
+    },
+    {
+      "type": "single",
+      "resource": "gbook:misc/paper"
     }
   ]
 }


### PR DESCRIPTION
Fixes #123 