### PR TITLE
Add custom sprite source for book covers

### DIFF
--- a/src/main/java/dev/gigaherz/guidebook/client/ClientHandlers.java
+++ b/src/main/java/dev/gigaherz/guidebook/client/ClientHandlers.java
@@ -23,6 +23,7 @@ import net.neoforged.neoforge.client.event.ModelEvent;
 import net.neoforged.neoforge.client.event.RegisterParticleProvidersEvent;
 import net.neoforged.neoforge.client.event.RegisterShadersEvent;
 import net.neoforged.neoforge.client.event.RegisterSpecialModelRendererEvent;
+import net.neoforged.neoforge.client.event.RegisterSpriteSourceTypesEvent;
 
 import java.io.IOException;
 import java.util.function.Function;
@@ -82,6 +83,11 @@ public class ClientHandlers
         public static void shaderRegistry(RegisterShadersEvent event) throws IOException
         {
             event.registerShader(CustomRenderTypes.BRIGHT_SOLID_SHADER);
+        }
+
+        @SubscribeEvent
+        static void onRegisterSpriteSourceTypes(RegisterSpriteSourceTypesEvent event) {
+            event.register(CoverLister.ID, CoverLister.TYPE);
         }
     }
 

--- a/src/main/java/dev/gigaherz/guidebook/client/CoverLister.java
+++ b/src/main/java/dev/gigaherz/guidebook/client/CoverLister.java
@@ -7,7 +7,6 @@ import dev.gigaherz.guidebook.GuidebookMod;
 import dev.gigaherz.guidebook.guidebook.BookRegistry;
 import net.minecraft.client.renderer.texture.atlas.SpriteSource;
 import net.minecraft.client.renderer.texture.atlas.SpriteSourceType;
-import net.minecraft.resources.FileToIdConverter;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
@@ -26,10 +25,9 @@ public record CoverLister(Optional<String> idPrefix) implements SpriteSource {
 
     @Override
     public void run(ResourceManager resourceManager, Output output) {
-        FileToIdConverter converter = new FileToIdConverter("textures", ".png");
         BookRegistry.gatherBookCovers().forEach((cover) -> {
             ResourceLocation id = this.idPrefix.isPresent() ? cover.withPrefix(this.idPrefix.get()) : cover;
-            Optional<Resource> resource = resourceManager.getResource(converter.idToFile(cover));
+            Optional<Resource> resource = resourceManager.getResource(TEXTURE_ID_CONVERTER.idToFile(cover));
             if (resource.isPresent())
                 output.add(id, resource.get());
         });

--- a/src/main/java/dev/gigaherz/guidebook/client/CoverLister.java
+++ b/src/main/java/dev/gigaherz/guidebook/client/CoverLister.java
@@ -1,0 +1,42 @@
+package dev.gigaherz.guidebook.client;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import dev.gigaherz.guidebook.GuidebookMod;
+import dev.gigaherz.guidebook.guidebook.BookRegistry;
+import net.minecraft.client.renderer.texture.atlas.SpriteSource;
+import net.minecraft.client.renderer.texture.atlas.SpriteSourceType;
+import net.minecraft.resources.FileToIdConverter;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.Resource;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import java.util.Optional;
+
+@OnlyIn(Dist.CLIENT)
+public record CoverLister(Optional<String> idPrefix) implements SpriteSource {
+
+    private static final MapCodec<CoverLister> CODEC = RecordCodecBuilder.mapCodec(inst -> inst.group(
+            Codec.STRING.optionalFieldOf("prefix").forGetter(lister -> lister.idPrefix)).apply(inst, CoverLister::new));
+    public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(GuidebookMod.MODID, "covers");
+    public static final SpriteSourceType TYPE = new SpriteSourceType(CODEC);
+
+    @Override
+    public void run(ResourceManager resourceManager, Output output) {
+        FileToIdConverter converter = new FileToIdConverter("textures", ".png");
+        BookRegistry.gatherBookCovers().forEach((cover) -> {
+            ResourceLocation id = this.idPrefix.isPresent() ? cover.withPrefix(this.idPrefix.get()) : cover;
+            Optional<Resource> resource = resourceManager.getResource(converter.idToFile(cover));
+            if (resource.isPresent())
+                output.add(id, resource.get());
+        });
+    }
+
+    @Override
+    public SpriteSourceType type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/dev/gigaherz/guidebook/guidebook/BookRegistry.java
+++ b/src/main/java/dev/gigaherz/guidebook/guidebook/BookRegistry.java
@@ -32,6 +32,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class BookRegistry
 {
@@ -365,14 +366,14 @@ public class BookRegistry
         }
     }
 
-    public static ResourceLocation[] gatherStandaloneBookModels()
+    public static Stream<ResourceLocation> gatherStandaloneBookModels()
     {
-        return getLoadedBooks().values().stream().map(BookDocument::getModelStandalone).filter(Objects::nonNull).distinct().toArray(ResourceLocation[]::new);
+        return getLoadedBooks().values().stream().map(BookDocument::getModelStandalone).filter(Objects::nonNull).distinct();
     }
 
-    public static ResourceLocation[] gatherBookCovers()
+    public static Stream<ResourceLocation> gatherBookCovers()
     {
-        return getLoadedBooks().values().stream().map(BookDocument::getCover).filter(Objects::nonNull).distinct().toArray(ResourceLocation[]::new);
+        return getLoadedBooks().values().stream().map(BookDocument::getCover).filter(Objects::nonNull).distinct();
     }
 
     public static void initClientResourceListener(ReloadableResourceManager clientResourceManager)

--- a/src/main/java/dev/gigaherz/guidebook/guidebook/client/BookBakedModel.java
+++ b/src/main/java/dev/gigaherz/guidebook/guidebook/client/BookBakedModel.java
@@ -151,13 +151,11 @@ public class BookBakedModel implements BakedModel
         {
             baseModel.resolveDependencies(resolver);
 
-            for (ResourceLocation bookModel : BookRegistry.gatherStandaloneBookModels())
-            {
+            BookRegistry.gatherStandaloneBookModels().forEach((bookModel) -> {
                 bookModels.computeIfAbsent(bookModel, resolver::resolve);
-            }
+            });
 
-            for (ResourceLocation bookCover : BookRegistry.gatherBookCovers())
-            {
+            BookRegistry.gatherBookCovers().forEach((bookCover) -> {
                 coverModels.computeIfAbsent(bookCover, (loc) -> {
                     BlockModel mdl = new BlockModel(
                             ResourceLocation.fromNamespaceAndPath(bookCover.getNamespace(), "generated/cover_models/" + bookCover.getPath()),
@@ -169,7 +167,7 @@ public class BookBakedModel implements BakedModel
                     //mdl.resolveDependencies(resolver);
                     return mdl;
                 });
-            }
+            });
         }
     }
 

--- a/src/main/resources/assets/minecraft/atlases/blocks.json
+++ b/src/main/resources/assets/minecraft/atlases/blocks.json
@@ -2,9 +2,7 @@
 {
   "sources": [
     {
-      "type": "directory",
-      "source": "covers",
-      "prefix": "covers/"
+      "type": "gbook:covers"
     },
     {
       "type": "single",


### PR DESCRIPTION
This PR adds a custom sprite source that ensures all book covers referenced in the guidebook XML files are included in the atlas stitching process, even if they are not located in the `textures/covers` directory.